### PR TITLE
Install appropriate PHP_CodeSniffer.

### DIFF
--- a/github/files/drupal7/scripts/sniffers.yml
+++ b/github/files/drupal7/scripts/sniffers.yml
@@ -20,7 +20,8 @@
     ignore_path: sites/all/themes/circle
     composer_global_require:
       - drupal/coder:dev-7.x-2.x
-      - squizlabs/php_codesniffer=*
+      # Use PHP_CodeSniffer 2.x for Drupal 8 and 1.x for Drupal 7.
+      - squizlabs/php_codesniffer=1.5.6
     git_repos:
       - { branch: 'master', repo: 'http://git.drupal.org/sandbox/coltrane/1921926.git', name: 'DrupalSecure' } # git clone --branch master http://git.drupal.org/sandbox/coltrane/1921926.git DrupalSecure
       - { branch: '7.x-1.x', repo: 'https://github.com/klausi/drupalpractice.git', name: 'DrupalPractice' } #git clone --branch 7.x-1.x https://github.com/klausi/drupalpractice.git DrupalPractice

--- a/jenkinsbox.yml
+++ b/jenkinsbox.yml
@@ -50,7 +50,7 @@
       - pear.drush.org
     pear_packages:
       - drush/drush
-      # PHP_CodeSniffer 2.x.x not supported. Please, check for 1.x version.
+      # Use PHP_CodeSniffer 2.x for Drupal 8 and 1.x for Drupal 7.
       - pear/PHP_CodeSniffer-1.5.6
     apt_repos:
       - ppa:chris-lea/node.js


### PR DESCRIPTION
Since Dec 18, 2014 has been released PHP_CodeSniffer 2.1.0 as stable version, we need install 1.5.6 version.
