### PR TITLE
Add libaugeas-ruby package to avoid related warnings on vagrant up

### DIFF
--- a/github/files/vagrant/puppet/puphpet/config.yaml
+++ b/github/files/vagrant/puppet/puphpet/config.yaml
@@ -54,6 +54,7 @@ server:
         - php5-memcache
         - unzip
         - libaugeas-dev
+        - libaugeas-ruby
     dot_files:
         - bash_aliases: null
     _prevent_empty: ''


### PR DESCRIPTION
#46 Issues related PR.

All other parts (memory, modifications to manifest, etc) are done already.
