### PR TITLE
Adding drupal and sniffers testing

### DIFF
--- a/github/files/drupal7/scripts/sniffers.yml
+++ b/github/files/drupal7/scripts/sniffers.yml
@@ -104,7 +104,7 @@
 
   - name: Install composer global requires
     sudo: yes
-    shell: "cd {{ composer_dir }} && composer require {{ item }}"
+    shell: "cd {{ composer_dir }} && composer require --prefer-dist {{ item }}"
     with_items: composer_global_require
     tags:
       - sniffers
@@ -200,4 +200,5 @@
     with_items: scsslint_folders
 
   - name: Website credentials
-    lineinfile: dest={{ workspace_root }}/{{ artifacts_file }} line="Build site installed at {{ webroot }}"
+    sudo: yes
+    lineinfile: dest={{ workspace_root }}/{{ artifacts_file }} line="Build site installed at {{ webroot }}" create=yes state=present

--- a/github/files/vagrant/puppet/Vagrantfile
+++ b/github/files/vagrant/puppet/Vagrantfile
@@ -67,6 +67,11 @@ Vagrant.configure("2") do |config|
   # Install ansible playbooks inside the box.
   config.vm.provision :shell, :path => "puphpet/ansible/run-ansible-playbook.sh"
 
+  # Install drupal within vm for testing.
+    if !ENV['VAGRANT_CI'].empty?
+      config.vm.provision :shell, :path => "puphpet/ansible/run-drupal-playbook.sh"
+    end
+
   config.ssh.username = "vagrant"
   config.ssh.password = "vagrant"
   config.ssh.shell = "sh"

--- a/github/files/vagrant/puppet/puphpet/ansible/run-drupal-playbook.sh
+++ b/github/files/vagrant/puppet/puphpet/ansible/run-drupal-playbook.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+export PYTHONUNBUFFERED=1
+
+playbooks=(
+/var/www/drupal/reinstall.yml \
+/var/www/drupal/sniffers.yml \
+)
+
+for i in "${playbooks[@]}"
+do
+   echo "Install "${i}
+   ansible-playbook ${i}
+   if [ "$?" == "0" ]; then
+    echo "Finished installing "${i}
+   else
+    echo "Failed installing "${i}
+    exit 1
+   fi
+done

--- a/github/files/vagrant/puppet/puphpet/shell/ansible.sh
+++ b/github/files/vagrant/puppet/puphpet/shell/ansible.sh
@@ -3,7 +3,7 @@
 echo 'Installing base packages for ansible'
 export "DEBIAN_FRONTEND=noninteractive"
 # ansible needs python.
-apt-get -y install python-simplejson sudo curl make rsync >/dev/null
+apt-get -y install python-simplejson sudo curl make rsync git >/dev/null
 
 # because basic ubuntu is too stripped down we need to add logging.
 apt-get --reinstall install -y bsdutils >/dev/null


### PR DESCRIPTION
- fixed sniffers.yml for avoiding error with unavailable commentinfo.md
- added script for running drupal and sniffers within vm on CI server for test
- fixed composer used to download via source. Now it will do that via dist.
- added git as dependency
# Steps for review
- run `VAGRANT_CI=yes vagrant up` for creating vm with lxc containers
- machine should be up and running without errors in console
- you may check drupal installed within wm by `VAGRANT_CI=yes vagrant ssh` and going to `cd /var/www/drupal` for check.
