### PR TITLE
Change local host to 127.0.0.1 as all others.

### DIFF
--- a/github/files/tests/local_setup/tests.yml
+++ b/github/files/tests/local_setup/tests.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: local
+- hosts: 127.0.0.1
   connection: local
   gather_facts: no
 


### PR DESCRIPTION
All ansible scripts on vagrant box use 127.0.0.1 so selenium installation should do that as well.
