### PR TITLE
PHPCS will check for changed files in PR and generate an additional report for these files

### DIFF
--- a/core/cibox-jenkins/templates/jobs/pr_builder.xml.j2
+++ b/core/cibox-jenkins/templates/jobs/pr_builder.xml.j2
@@ -80,7 +80,7 @@ sudo rsync -avz docroot/ /var/www/build${BUILD_NUMBER}
 cd /var/www/build${BUILD_NUMBER}
 sudo chown -R www-data:jenkins *
 ansible-playbook reinstall.yml -i 'localhost,' --connection=local --extra-vars "php_env_vars='APP_ENV=dev' mysql_user=root mysql_pass=root mysql_db=drupal${BUILD_NUMBER} drupal_folder=/var/www/build${BUILD_NUMBER} site_url=http://{{ jenkins_server_ip }}/build${BUILD_NUMBER} pp_environment='default'"
-ansible-playbook sniffers.yml -i 'localhost,' --connection=local --extra-vars "workspace_root=${WORKSPACE} webroot=http://{{ jenkins_server_ip }}/build${BUILD_NUMBER}"
+ansible-playbook sniffers.yml -i 'localhost,' --connection=local --extra-vars "workspace_root=${WORKSPACE} webroot=http://{{ jenkins_server_ip }}/build${BUILD_NUMBER} source_hash=${ghprbActualCommit} target_branch=${ghprbTargetBranch} pr_workspace=${WORKSPACE}/new_pull_request"
 ansible-playbook tests.yml -i 'localhost,' --connection=local --extra-vars "workspace_root=${WORKSPACE} behat_base_url=http://{{ jenkins_server_ip }}/build${BUILD_NUMBER} update_dependencies='yes' resources_path=${WORKSPACE}/new_pull_request//tests/behat/resources
 behat_drupal_root=/var/www/build${BUILD_NUMBER}
 behat_root=${WORKSPACE}/new_pull_request/tests/behat"

--- a/core/cibox-project-builder/files/drupal7/scripts/sniffers.yml
+++ b/core/cibox-project-builder/files/drupal7/scripts/sniffers.yml
@@ -12,6 +12,7 @@
     webroot: http://localhost
     installation_profile_name: pp
     docroot: docroot/
+    sniff_diffs: false
     installation_profile_path: "profiles/{{ installation_profile_name }}"
     scan_security: true
     phpcs_extensions: php,inc,install,module
@@ -192,7 +193,7 @@
       shell: "git fetch origin {{ target_branch }}"
       args:
         chdir: "{{ pr_workspace }}"
-      when: source_hash is defined
+      when: (source_hash is defined) and sniff_diffs
 
     - name: Get branching point hash
       shell: "diff -u1 <(git rev-list --first-parent {{ source_hash }}) <(git rev-list --first-parent origin/{{ target_branch }}) | sed -ne 's/^ //p'"
@@ -200,11 +201,11 @@
         executable: /bin/bash
         chdir: "{{ pr_workspace }}"
       register: branching_hash
-      when: source_hash is defined
+      when: (source_hash is defined) and sniff_diffs
 
     - name: Get branching point hash stdout
       set_fact: branching_hash_stdout={{ branching_hash.stdout }}
-      when: source_hash is defined
+      when: (source_hash is defined) and sniff_diffs
 
     - name: Populate list of changed files for sniffers
       shell: "git diff --name-only --diff-filter=ACMRTUXB {{ branching_hash_stdout }} {{ source_hash }} | sed -e 's@{{ docroot }}@@g' | grep -E '({{ features_path }}|{{ custom_modules_path }}|{{ custom_themes_path }})' | tr '\n' ' '"
@@ -212,23 +213,23 @@
         executable: /bin/bash
         chdir: "{{ pr_workspace }}"
       register: changed_files
-      when: branching_hash_stdout is defined
+      when: (branching_hash_stdout is defined) and sniff_diffs
 
     - name: Populate list of changed files for sniffers stdout
       set_fact: changed_files_stdout={{ changed_files.stdout }}
-      when: branching_hash_stdout is defined
+      when: (branching_hash_stdout is defined) and sniff_diffs
 
     - name: PHP CodeSniffer for changed files run
       shell: '{{ phpcs_bin }} --standard={{ item.name }} --extensions={{ phpcs_features_extensions }} -n {{ changed_files_stdout }} --report-file={{ build_reports_dir }}/ChangedFiles{{ item.name }}sniff.txt --ignore={{ phpcs_features_ignore | join(",") }} || true'
       with_items: phpcs_standards
-      when: changed_files_stdout is defined
+      when: (changed_files_stdout is defined) and sniff_diffs
 
     - name: PHP CodeSniffer for changed files reports build
       ignore_errors: yes
       shell: 'if grep "FOUND" {{ build_reports_dir }}/ChangedFiles{{ item.name }}sniff.txt; then echo "<strong>`grep -o "\<\| ERROR \|\>" {{ build_reports_dir }}/ChangedFiles{{ item.name }}sniff.txt | wc -l`</strong> errors for CodeSniffer in Changed Files: {{ item.name }} standard file {{ webroot }}/{{ build_reports_dir }}/ChangedFiles{{ item.name }}sniff.txt" >> {{ workspace_root }}/{{ artifacts_file }} && exit 1; fi'
       with_items: phpcs_standards
       when: changed_files_stdout is defined
-      when: changed_files is defined
+      when: (changed_files is defined) and sniff_diffs
 
     - name: PHP CodeSniffer reports build
       ignore_errors: yes

--- a/core/cibox-project-builder/files/drupal7/scripts/sniffers.yml
+++ b/core/cibox-project-builder/files/drupal7/scripts/sniffers.yml
@@ -11,6 +11,7 @@
     artifacts_file: commentinfo.md
     webroot: http://localhost
     installation_profile_name: pp
+    docroot: docroot/
     installation_profile_path: "profiles/{{ installation_profile_name }}"
     scan_security: true
     phpcs_extensions: php,inc,install,module
@@ -186,6 +187,48 @@
     - name: PHP CodeSniffer run
       shell: '{{ phpcs_bin }} --standard={{ item.name }} --extensions={{ phpcs_extensions }} -n {{ custom_modules_path }} {{ installation_profile_path }} {{ custom_themes_path }} --report-file={{ build_reports_dir }}/{{ item.name }}sniff.txt --ignore={{ phpcs_modules_ignore | join(",") }} || true'
       with_items: phpcs_standards
+
+    - name: Get latest develop
+      shell: "git fetch origin {{ target_branch }}"
+      args:
+        chdir: "{{ pr_workspace }}"
+      when: source_hash is defined
+
+    - name: Get branching point hash
+      shell: "diff -u1 <(git rev-list --first-parent {{ source_hash }}) <(git rev-list --first-parent origin/{{ target_branch }}) | sed -ne 's/^ //p'"
+      args:
+        executable: /bin/bash
+        chdir: "{{ pr_workspace }}"
+      register: branching_hash
+      when: source_hash is defined
+
+    - name: Get branching point hash stdout
+      set_fact: branching_hash_stdout={{ branching_hash.stdout }}
+      when: source_hash is defined
+
+    - name: Populate list of changed files for sniffers
+      shell: "git diff --name-only --diff-filter=ACMRTUXB {{ branching_hash_stdout }} {{ source_hash }} | sed -e 's@{{ docroot }}@@g' | grep -E '({{ features_path }}|{{ custom_modules_path }}|{{ custom_themes_path }})' | tr '\n' ' '"
+      args:
+        executable: /bin/bash
+        chdir: "{{ pr_workspace }}"
+      register: changed_files
+      when: branching_hash_stdout is defined
+
+    - name: Populate list of changed files for sniffers stdout
+      set_fact: changed_files_stdout={{ changed_files.stdout }}
+      when: branching_hash_stdout is defined
+
+    - name: PHP CodeSniffer for changed files run
+      shell: '{{ phpcs_bin }} --standard={{ item.name }} --extensions={{ phpcs_features_extensions }} -n {{ changed_files_stdout }} --report-file={{ build_reports_dir }}/ChangedFiles{{ item.name }}sniff.txt --ignore={{ phpcs_features_ignore | join(",") }} || true'
+      with_items: phpcs_standards
+      when: changed_files_stdout is defined
+
+    - name: PHP CodeSniffer for changed files reports build
+      ignore_errors: yes
+      shell: 'if grep "FOUND" {{ build_reports_dir }}/ChangedFiles{{ item.name }}sniff.txt; then echo "<strong>`grep -o "\<\| ERROR \|\>" {{ build_reports_dir }}/ChangedFiles{{ item.name }}sniff.txt | wc -l`</strong> errors for CodeSniffer in Changed Files: {{ item.name }} standard file {{ webroot }}/{{ build_reports_dir }}/ChangedFiles{{ item.name }}sniff.txt" >> {{ workspace_root }}/{{ artifacts_file }} && exit 1; fi'
+      with_items: phpcs_standards
+      when: changed_files_stdout is defined
+      when: changed_files is defined
 
     - name: PHP CodeSniffer reports build
       ignore_errors: yes


### PR DESCRIPTION
This feature will be useful for projects that have excluded a PHPCS check in the past, but now want to work on coding standards improvement. PHPCS will run an additional set of sniffs on the files modified in a PR and will display an additional report. I have positioned these reports at the top since they can be visually lost in the variety of reports.
Additional variables will have to be transferred to the playbook:
source_hash=${ghprbActualCommit} -> a variable exisiting in GitHubPullRequestBuiler, representing commit hash
target_branch=${ghprbTargetBranch} -> a variable exisiting in GitHubPullRequestBuiler, representing a branch in which a PR is to be merged
pr_workspace=${WORKSPACE}/new_pull_request" -> original folder in which git commands can be ran

If the playbook will be run without these additional variables - then it will just skip the steps.

Variable sniff_diffs is used to trigger this feature. It is disabled by default. 
