### PR TITLE
Use ansible plugin instead of bash

### DIFF
--- a/core/cibox-jenkins/defaults/main.yml
+++ b/core/cibox-jenkins/defaults/main.yml
@@ -35,6 +35,7 @@ plugins:
   - 'http://mirrors.jenkins-ci.org/plugins/scripttrigger/0.31/scripttrigger.hpi'
   - 'http://mirrors.jenkins-ci.org/plugins/parameterized-trigger/2.28/parameterized-trigger.hpi'
   - 'http://mirrors.jenkins-ci.org/plugins/simple-theme-plugin/0.3/simple-theme-plugin.hpi'
+  - 'http://mirrors.jenkins-ci.org/plugins/ansible/0.5/ansible.hpi'
 
 jenkins_pkg_version: 'http://pkg.jenkins-ci.org/debian/binary/jenkins_1.624_all.deb'
 

--- a/core/cibox-jenkins/templates/jobs/server_cleaner.xml.j2
+++ b/core/cibox-jenkins/templates/jobs/server_cleaner.xml.j2
@@ -51,11 +51,26 @@
   </triggers>
   <concurrentBuild>false</concurrentBuild>
   <builders>
-    <hudson.tasks.Shell>
-      <command>export PYTHONUNBUFFERED=1
-ansible-playbook sourcecode/cibox/jobs/server_cleaner.yml -i &apos;localhost,&apos; --connection=local
-</command>
-    </hudson.tasks.Shell>
+    <org.jenkinsci.plugins.ansible.AnsiblePlaybookBuilder plugin="ansible@0.5">
+      <playbook>${WORKSPACE}/sourcecode/cibox/jobs/server_cleaner.yml</playbook>
+      <inventory class="org.jenkinsci.plugins.ansible.InventoryContent">
+        <content></content>
+        <dynamic>false</dynamic>
+      </inventory>
+      <limit></limit>
+      <tags></tags>
+      <skippedTags></skippedTags>
+      <startAtTask></startAtTask>
+      <credentialsId></credentialsId>
+      <sudo>false</sudo>
+      <sudoUser></sudoUser>
+      <forks>5</forks>
+      <unbufferedOutput>true</unbufferedOutput>
+      <colorizedOutput>false</colorizedOutput>
+      <hostKeyChecking>false</hostKeyChecking>
+      <additionalParameters> -i &apos;localhost,&apos; --connection=local</additionalParameters>
+      <copyCredentialsInWorkspace>false</copyCredentialsInWorkspace>
+    </org.jenkinsci.plugins.ansible.AnsiblePlaybookBuilder>
   </builders>
   <publishers/>
   <buildWrappers/>


### PR DESCRIPTION
This PR replaces bash script with Ansible plugin that invokes Ansible playbook.

It's easier to define all extra vars and with that update there will be no way to customize base script within Jenkins UI.

With that update later we should be able to run playbook on other environments(e.g. docker) just by using another inventory. See screenshot.

![image](https://cloud.githubusercontent.com/assets/1316234/16893554/8ddfbe98-4b44-11e6-9f59-d5dd32042656.png)
