### PR TITLE
Add security_updater job

### DIFF
--- a/core/cibox-env/defaults/main.yml
+++ b/core/cibox-env/defaults/main.yml
@@ -28,6 +28,7 @@ apt_packages:
   - { name: "rng-tools", status: true }
   - { name: "cgroup-bin", status: true }
   - { name: "git", status: true }
+  - { name: "unattended-upgrades", status: true}
 
 pip_packages:
   - setuptools

--- a/core/cibox-jenkins/defaults/main.yml
+++ b/core/cibox-jenkins/defaults/main.yml
@@ -37,6 +37,7 @@ plugins:
   - 'http://mirrors.jenkins-ci.org/plugins/simple-theme-plugin/0.3/simple-theme-plugin.hpi'
   - 'http://mirrors.jenkins-ci.org/plugins/ansible/0.5/ansible.hpi'
   - 'http://mirrors.jenkins-ci.org/plugins/jobConfigHistory/2.14/jobConfigHistory.hpi'
+  - 'http://mirrors.jenkins-ci.org/plugins/slack/1.8/slack.hpi'
 
 jenkins_pkg_version: 'http://pkg.jenkins-ci.org/debian/binary/jenkins_1.624_all.deb'
 
@@ -49,6 +50,7 @@ jenkins_jobs:
   - { name: 'DISK_USAGE_TRIGGER', template: 'disk_usage_trigger.xml.j2', status: true }
   - { name: 'PR_BUILDER', template: 'pr_builder.xml.j2', status: true }
   - { name: 'SERVER_CLEANER', template: 'server_cleaner.xml.j2', status: true }
+  - { name: 'SERVER_SECURITY_UPD', template: 'server_security.xml.j2', status: true }
 
 jenkins_users:
   - { name: 'root', template: 'root.xml.j2', status: true }

--- a/core/cibox-jenkins/templates/jobs/server_security.xml.j2
+++ b/core/cibox-jenkins/templates/jobs/server_security.xml.j2
@@ -1,0 +1,52 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description>Regular task that aims to auto update server&apos;s security per cron task</description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <jenkins.plugins.slack.SlackNotifier_-SlackJobProperty plugin="slack@1.8">
+      <teamDomain>CHANGE_ME</teamDomain>
+      <token>CHANGE_ME</token>
+      <room>CHANGE_ME</room>
+      <startNotification>true</startNotification>
+      <notifySuccess>true</notifySuccess>
+      <notifyAborted>false</notifyAborted>
+      <notifyNotBuilt>false</notifyNotBuilt>
+      <notifyUnstable>false</notifyUnstable>
+      <notifyFailure>true</notifyFailure>
+      <notifyBackToNormal>true</notifyBackToNormal>
+      <notifyRepeatedFailure>false</notifyRepeatedFailure>
+      <includeTestSummary>false</includeTestSummary>
+      <showCommitList>false</showCommitList>
+      <includeCustomMessage>false</includeCustomMessage>
+      <customMessage></customMessage>
+    </jenkins.plugins.slack.SlackNotifier_-SlackJobProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers>
+    <hudson.triggers.TimerTrigger>
+      <spec>5 8 * * 0</spec>
+    </hudson.triggers.TimerTrigger>
+  </triggers>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>
+         sudo apt-get update || true
+         sudo unattended-upgrades -d
+      </command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers>
+    <jenkins.plugins.slack.SlackNotifier plugin="slack@1.8">
+      <teamDomain>CHANGE_ME</teamDomain>
+      <authToken>CHANGE_ME</authToken>
+      <buildServerUrl>http://{{ jenkins_server_ip }}:8080/</buildServerUrl>
+      <room>CHANGE_ME</room>
+    </jenkins.plugins.slack.SlackNotifier>
+  </publishers>
+  <buildWrappers/>

--- a/core/cibox-jenkins/templates/jobs/server_security.xml.j2
+++ b/core/cibox-jenkins/templates/jobs/server_security.xml.j2
@@ -24,7 +24,7 @@
   </properties>
   <scm class="hudson.scm.NullSCM"/>
   <canRoam>true</canRoam>
-  <disabled>false</disabled>
+  <disabled>true</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
   <triggers>


### PR DESCRIPTION
This task aims to cover time consuming task about server security updates.
Runs every Sunday or could be executed by hands per request.
Disabled by default