### PR TITLE
Do not automatically update VirtualBox guest additions

### DIFF
--- a/core/cibox-project-builder/files/vagrant/box/Vagrantfile
+++ b/core/cibox-project-builder/files/vagrant/box/Vagrantfile
@@ -101,4 +101,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.ssh.insert_key = "false"
   config.ssh.forward_agent = true
 
+  # Do not update additions.
+  config.vbguest.auto_update = false
+
 end


### PR DESCRIPTION
There are problems with `Ubuntu 16.04` and `vagrant-vbguest` plugin, which tries automatically update VirtualBox guest additions.

There is a config which prevents this behavior. Add in the PR.