### PR TITLE
Add and enable timestamper

### DIFF
--- a/core/cibox-jenkins/defaults/main.yml
+++ b/core/cibox-jenkins/defaults/main.yml
@@ -38,6 +38,7 @@ plugins:
   - 'http://mirrors.jenkins-ci.org/plugins/ansible/0.5/ansible.hpi'
   - 'http://mirrors.jenkins-ci.org/plugins/jobConfigHistory/2.14/jobConfigHistory.hpi'
   - 'http://mirrors.jenkins-ci.org/plugins/slack/1.8/slack.hpi'
+  - 'http://mirrors.jenkins-ci.org/plugins/timestamper/1.8.5/timestamper.hpi'
 
 jenkins_pkg_version: 'http://pkg.jenkins-ci.org/debian/binary/jenkins_1.624_all.deb'
 

--- a/core/cibox-jenkins/templates/jobs/backup_prod_db.xml.j2
+++ b/core/cibox-jenkins/templates/jobs/backup_prod_db.xml.j2
@@ -44,6 +44,7 @@ scp root@CHANGE_TO_PROD_SERVER_I:/var/www/backup/proddump.sql.gz /var/www/backup
     </builders>
     <publishers/>
     <buildWrappers>
+        <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.8.4"/>
         <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@0.4.1">
             <colorMapName>xterm</colorMapName>
         </hudson.plugins.ansicolor.AnsiColorBuildWrapper>

--- a/core/cibox-jenkins/templates/jobs/demo.xml.j2
+++ b/core/cibox-jenkins/templates/jobs/demo.xml.j2
@@ -67,6 +67,7 @@ sudo chown -R www-data:jenkins ../demo</command>
   </builders>
   <publishers/>
   <buildWrappers>
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.8.4"/>
     <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@0.4.0">
       <colorMapName>xterm</colorMapName>
     </hudson.plugins.ansicolor.AnsiColorBuildWrapper>

--- a/core/cibox-jenkins/templates/jobs/disk_usage_trigger.xml.j2
+++ b/core/cibox-jenkins/templates/jobs/disk_usage_trigger.xml.j2
@@ -57,5 +57,7 @@ fi
     </hudson.plugins.parameterizedtrigger.TriggerBuilder>
   </builders>
   <publishers/>
-  <buildWrappers/>
+  <buildWrappers>
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.8.4"/>
+  </buildWrappers>
 </project>

--- a/core/cibox-jenkins/templates/jobs/pr_builder.xml.j2
+++ b/core/cibox-jenkins/templates/jobs/pr_builder.xml.j2
@@ -310,6 +310,7 @@
   </builders>
   <publishers/>
   <buildWrappers>
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.8.4"/>
     <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@0.4.1">
       <colorMapName>xterm</colorMapName>
     </hudson.plugins.ansicolor.AnsiColorBuildWrapper>

--- a/core/cibox-jenkins/templates/jobs/server_cleaner.xml.j2
+++ b/core/cibox-jenkins/templates/jobs/server_cleaner.xml.j2
@@ -81,5 +81,7 @@
     </org.jenkinsci.plugins.ansible.AnsiblePlaybookBuilder>
   </builders>
   <publishers/>
-  <buildWrappers/>
+  <buildWrappers>
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.8.4"/>
+  </buildWrappers>
 </project>

--- a/core/cibox-jenkins/templates/jobs/server_security.xml.j2
+++ b/core/cibox-jenkins/templates/jobs/server_security.xml.j2
@@ -57,4 +57,6 @@
       <room>CHANGE_ME</room>
     </jenkins.plugins.slack.SlackNotifier>
   </publishers>
-  <buildWrappers/>
+  <buildWrappers>
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.8.4"/>
+  </buildWrappers>


### PR DESCRIPTION
This PR adds and enables Jenkins Plugin - Timestamper https://wiki.jenkins-ci.org/display/JENKINS/Timestamper.

Also it updates all jobs to add timestamps to console output.