### PR TITLE
Configure all database params and "trusted_host_patterns" for Drupal 8

### DIFF
--- a/core/cibox-project-builder/files/drupal7/scripts/devops/reinstall/pre_settings.yml
+++ b/core/cibox-project-builder/files/drupal7/scripts/devops/reinstall/pre_settings.yml
@@ -16,9 +16,22 @@
   sudo: yes
   shell: "cp {{ settings_default_file_path }} {{ platform_settings_file }}"
 
-- name: Adding database variable to settings.php
-  sudo: yes
-  lineinfile: dest='{{ platform_settings_file }}' line='$databases = array(\"default\" => array (\"default\" => array (\"database\" => \"{{ mysql_db }}\", \"username\" => \"{{ mysql_user }}\", \"password\" => \"{{ mysql_pass }}\", \"host\" => \"{{ mysql_host }}\", \"port\" => \"\", \"driver\" => \"mysql\", \"prefix\" => \"\", ), ), );'
+- name: Adding $databases variable to settings.php
+  lineinfile:
+    dest: "{{ platform_settings_file }}"
+    line: "$databases = array(
+      'default' => array(
+        'default' => array(
+          'database' => '{{ mysql_db }}',
+          'username' => '{{ mysql_user }}',
+          'password' => '{{ mysql_pass }}',
+          'driver' => '{{ mysql_driver | default('mysql') }}',
+          'prefix' => '{{ mysql_prefix | default }}',
+          'port' => {{ mysql_port | default(3306) }},
+          'host' => '{{ mysql_host }}',
+        ),
+      ),
+    );"
 
 - name: Add general pre-settings to settings.php
   lineinfile: dest='{{ platform_settings_file }}' line='{{ item.name }} = \"{{ item.value }}\";'

--- a/core/cibox-project-builder/files/drupal8/scripts/devops/reinstall/pre_settings.yml
+++ b/core/cibox-project-builder/files/drupal8/scripts/devops/reinstall/pre_settings.yml
@@ -16,9 +16,28 @@
   sudo: yes
   shell: "cp {{ settings_default_file_path }} {{ platform_settings_file }}"
 
-- name: Adding database variable to settings.php
-  sudo: yes
-  lineinfile: dest='{{ platform_settings_file }}' line='$databases = array(\"default\" => array (\"default\" => array (\"database\" => \"{{ mysql_db }}\", \"username\" => \"{{ mysql_user }}\", \"password\" => \"{{ mysql_pass }}\", \"host\" => \"127.0.0.1\", \"port\" => \"\", \"driver\" => \"mysql\", \"prefix\" => \"\", ), ), );'
+- name: Adding $databases variable to settings.php
+  lineinfile:
+    dest: "{{ platform_settings_file }}"
+    line: "$databases = [
+      'default' => [
+        'default' => [
+          'database' => '{{ mysql_db }}',
+          'username' => '{{ mysql_user }}',
+          'password' => '{{ mysql_pass }}',
+          'driver' => '{{ mysql_driver | default('mysql') }}',
+          'prefix' => '{{ mysql_prefix | default }}',
+          'port' => {{ mysql_port | default(3306) }},
+          'host' => '{{ mysql_host }}',
+        ],
+      ],
+    ];"
+
+- name: Adding trusted host patterns to settings.php
+  lineinfile:
+    dest: "{{ platform_settings_file }}"
+    line: "$settings['trusted_host_patterns'] = ['{{ (global_env.trusted_host_patterns + env.trusted_host_patterns) | join(\"', '\") }}'];"
+  when: global_env.trusted_host_patterns | length or env.trusted_host_patterns | length
 
 - name: Add general pre-settings to settings.php
   lineinfile: dest='{{ platform_settings_file }}' line='{{ item.name }} = \"{{ item.value }}\";'

--- a/core/cibox-project-builder/files/drupal8/scripts/devops/reinstall/vars/environments/default_env.yml
+++ b/core/cibox-project-builder/files/drupal8/scripts/devops/reinstall/vars/environments/default_env.yml
@@ -1,5 +1,6 @@
 ---
 env:
+  trusted_host_patterns: []
   pre_settings:
     - { name: '$config_directories["staging"]', status: false, value: 'sites/default/config/staging' }
     - { name: '$settings["install_profile"]', status: true, value: "{{ installation_profile_name }}" }

--- a/core/cibox-project-builder/files/drupal8/scripts/devops/reinstall/vars/environments/demo_env.yml
+++ b/core/cibox-project-builder/files/drupal8/scripts/devops/reinstall/vars/environments/demo_env.yml
@@ -1,5 +1,6 @@
 ---
 env:
+  trusted_host_patterns: []
   pre_settings: []
   modules: []
   drush_commands:

--- a/core/cibox-project-builder/files/drupal8/scripts/devops/reinstall/vars/environments/global_env.yml
+++ b/core/cibox-project-builder/files/drupal8/scripts/devops/reinstall/vars/environments/global_env.yml
@@ -1,5 +1,7 @@
 ---
 global_env:
+  # Protecting against HTTP HOST Header attacks (https://www.drupal.org/node/1992030).
+  trusted_host_patterns: []
   pre_settings: []
   modules: []
   drush_commands: []

--- a/core/cibox-project-builder/files/drupal8/scripts/devops/reinstall/vars/environments/production_env.yml
+++ b/core/cibox-project-builder/files/drupal8/scripts/devops/reinstall/vars/environments/production_env.yml
@@ -1,5 +1,6 @@
 ---
 env:
+  trusted_host_patterns: []
   pre_settings: []
   modules: []
   drush_commands: []

--- a/core/cibox-project-builder/files/drupal8/scripts/devops/reinstall/vars/environments/staging_env.yml
+++ b/core/cibox-project-builder/files/drupal8/scripts/devops/reinstall/vars/environments/staging_env.yml
@@ -1,5 +1,6 @@
 ---
 env:
+  trusted_host_patterns: []
   pre_settings: []
   modules: []
   drush_commands: []


### PR DESCRIPTION
### Changes

#### Drupal 7 & 8

- Allow to configure database `driver` parameter by defining the `mysql_driver: sqllite` variable.
- Allow to configure database `prefix` parameter by defining the `mysql_prefix: drpl_` variable.
- Allow to configure database `port` parameter by defining the `mysql_port: 4990` variable.

#### Drupal 8

- Allow to configure `$settings['trusted_host_patterns']` which been introduced here: https://www.drupal.org/node/2410395. Configuration could be done per environment, globally or using both of the ways.