### PR TITLE
Do a provision only if it manually requested ("vagrant provision" executed)

### DIFF
--- a/core/cibox-project-builder/files/vagrant/box/README.md
+++ b/core/cibox-project-builder/files/vagrant/box/README.md
@@ -100,9 +100,9 @@ apt-get install redir lxc cgroup-bin
 ```
 also you may need to apply this patch https://github.com/fgrehm/vagrant-lxc/pull/354
 
-When your system is enpowered by apparmor, you should enable nfs mounts for your host
+When your system is empowered by apparmor, you should enable nfs mounts for your host
 machine
-Do that by editing ```/etc/apparmor.d/lxc/lxc-default``` file with one line
+Do that by editing `/etc/apparmor.d/lxc/lxc-default` file with one line
 
 ```ruby
 profile lxc-container-default flags=(attach_disconnected,mediate_deleted) {
@@ -110,24 +110,17 @@ profile lxc-container-default flags=(attach_disconnected,mediate_deleted) {
     mount options=(rw, bind, ro),
   ...
 ```
+
 and reload apparmor service
 ```sh
 sudo /etc/init.d/apparmor reload
 ```
 
-
 and run the box by command
 
 ```sh
-VAGRANT_CI=yes vagrant up
+vagrant up --provider=lxc
 ```
-
-Do use 
-```
-VAGRANT_CI=yes
-```
-environment variable, if you got issues with all vagrant commands.
-
 
 Windows Containers
 =====

--- a/core/cibox-project-builder/files/vagrant/box/README.md
+++ b/core/cibox-project-builder/files/vagrant/box/README.md
@@ -18,7 +18,7 @@ vagrant up && vagrant ssh
 If you need to rerun provisioning
 
 ```sh
-FORCE_PROVISION=yes vagrant up && vagrant ssh
+vagrant provision
 ```
 
 **Drupal reinstallation from scratch**

--- a/core/cibox-project-builder/files/vagrant/box/Vagrantfile
+++ b/core/cibox-project-builder/files/vagrant/box/Vagrantfile
@@ -81,7 +81,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   # Do a provision only if it manually requested ("vagrant provision" executed).
-  if "provision" == ARGV[0]
+  # https://github.com/mitchellh/vagrant/issues/7043#issuecomment-197935659
+  if ARGV.include?("provision") || ARGV.include?("--provision")
     config.vm.provision "shell" do |s|
       s.path = "provisioning/shell/initial-setup.sh"
       s.args = "/vagrant/provisioning"

--- a/core/cibox-project-builder/files/vagrant/box/Vagrantfile
+++ b/core/cibox-project-builder/files/vagrant/box/Vagrantfile
@@ -2,33 +2,17 @@
 # vi: set ft=ruby :
 VAGRANTFILE_API_VERSION = "2"
 
-# Use rbconfig to determine if we're on a windows host or not.
-require 'rbconfig'
-is_windows = (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/)
-
-require 'yaml'
+require "yaml"
 
 dir = File.dirname(File.expand_path(__FILE__))
-
 configValues = YAML::load_file("#{dir}/provisioning/config.yaml")
 apacheConfigValues = YAML::load_file("#{dir}/provisioning/ansible/playbooks/www.yml")
-data = configValues['vagrantfile-local']
-
-if !data['vm']['provider']['virtualbox'].empty?
-  ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
-end
-if !ENV['VAGRANT_CI'].nil?
-  ENV['VAGRANT_DEFAULT_PROVIDER'] = 'lxc'
-end
+data = configValues["vagrantfile-local"]
+provider = (ARGV.include?("--provider=lxc") || !data["vm"]["provider"].key?("virtualbox")) ? "lxc" : "virtualbox"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "#{data['vm']['box']}"
-  config.vm.box_url = "#{data['vm']['box_url']}"
-
-  if !ENV['VAGRANT_CI'].nil?
-    config.vm.box = "#{data['vm']['provider']['lxc']['box']}"
-    config.vm.box_url = "#{data['vm']['provider']['lxc']['box_url']}"
-  end
+  config.vm.box = "#{data['vm']['provider'][provider]['box']}"
+  config.vm.box_url = "#{data['vm']['provider'][provider]['box_url']}"
 
   if data['vm']['hostname'].to_s != ''
     config.vm.hostname = "#{data['vm']['hostname']}"
@@ -83,15 +67,16 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Do a provision only if it manually requested ("vagrant provision" executed).
   # https://github.com/mitchellh/vagrant/issues/7043#issuecomment-197935659
   if ARGV.include?("provision") || ARGV.include?("--provision")
-    config.vm.provision "shell" do |s|
-      s.path = "provisioning/shell/initial-setup.sh"
-      s.args = "/vagrant/provisioning"
-    end
+    config.vm.provision :shell,
+      :path => "provisioning/shell/initial-setup.sh",
+      :args => "/vagrant/provisioning"
 
     # Install ansible inside the box.
-    config.vm.provision :shell, :path => "provisioning/shell/ansible.sh"
+    config.vm.provision :shell,
+      :path => "provisioning/shell/ansible.sh"
     # Install ansible playbooks inside the box.
-    config.vm.provision :shell, :path => "provisioning/ansible/run-ansible-playbook.sh"
+    config.vm.provision :shell,
+      :path => "provisioning/ansible/run-ansible-playbook.sh"
   end
 
   # Install drupal within vm for testing.
@@ -104,5 +89,4 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.ssh.shell = "sh"
   config.ssh.insert_key = "false"
   config.ssh.forward_agent = true
-
 end

--- a/core/cibox-project-builder/files/vagrant/box/Vagrantfile
+++ b/core/cibox-project-builder/files/vagrant/box/Vagrantfile
@@ -80,26 +80,23 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
   end
 
-if !ENV['FORCE_PROVISION'].nil?
-  config.vm.provision "shell" do |s|
-    s.path = "provisioning/shell/initial-setup.sh"
-    s.args = "/vagrant/provisioning"
-  end
-end
+  # Do a provision only if it manually requested ("vagrant provision" executed).
+  if "provision" == ARGV[0]
+    config.vm.provision "shell" do |s|
+      s.path = "provisioning/shell/initial-setup.sh"
+      s.args = "/vagrant/provisioning"
+    end
 
-  # Install ansible inside the box.
-    if !ENV['FORCE_PROVISION'].nil?
-      config.vm.provision :shell, :path => "provisioning/shell/ansible.sh"
-    end
-  # Install ansible playbooks inside the box.
-    if !ENV['FORCE_PROVISION'].nil?
-      config.vm.provision :shell, :path => "provisioning/ansible/run-ansible-playbook.sh"
-    end
+    # Install ansible inside the box.
+    config.vm.provision :shell, :path => "provisioning/shell/ansible.sh"
+    # Install ansible playbooks inside the box.
+    config.vm.provision :shell, :path => "provisioning/ansible/run-ansible-playbook.sh"
+  end
 
   # Install drupal within vm for testing.
-    if !ENV['VAGRANT_CI'].nil?
-      config.vm.provision :shell, :path => "provisioning/ansible/run-drupal-playbook.sh"
-    end
+  if !ENV['VAGRANT_CI'].nil?
+    config.vm.provision :shell, :path => "provisioning/ansible/run-drupal-playbook.sh"
+  end
 
   config.ssh.username = "vagrant"
   config.ssh.password = "vagrant"

--- a/core/cibox-project-builder/files/vagrant/box/provisioning/config.yaml
+++ b/core/cibox-project-builder/files/vagrant/box/provisioning/config.yaml
@@ -1,8 +1,6 @@
 ---
 vagrantfile-local:
     vm:
-        box: 'Ubuntu_14_04__CIBox_VM_provisioned'
-        box_url: 'http://cici.ffwua.com/ubuntu14.04provisionedCIBox.box'
         hostname: null
         network:
             private_network: 192.168.56.132
@@ -15,6 +13,8 @@ vagrantfile-local:
                     guest: '3306'
         provider:
             virtualbox:
+                box: 'Ubuntu_14_04__CIBox_VM_provisioned'
+                box_url: 'http://cici.ffwua.com/ubuntu14.04provisionedCIBox.box'
                 modifyvm:
                     natdnshostresolver1: on
                     memory: '2048'


### PR DESCRIPTION
Execute the VM provisioning when user manually executed the `vagrant provision` to get rid from additional environment variable - `FORCE_PROVISION`, - which adds more complexity to the application.