### PR TITLE
Added jinja2 dev as requirement to documentation

### DIFF
--- a/docs/Requirements.md
+++ b/docs/Requirements.md
@@ -1,5 +1,6 @@
 ## Provisioner and GitHub project builder
 ##### [Ansible](http://docs.ansible.com/ansible/intro_installation.html#installation) version 1.7-1.x. 2.0 not yet supported
+##### [Jinja2](http://jinja.pocoo.org/) version 2.8 (dev)
 
 ## Vagrant box
 ##### [Vagrant](https://www.vagrantup.com/downloads.html) version >= 1.6.2


### PR DESCRIPTION
Hi guys.

I have tried to provision new cibox instance and got an error:

```
File "/usr/local/lib/python2.7/dist-packages/ansible/runner/__init__.py", line 586, in _executor
    exec_rc = self._executor_internal(host, new_stdin)
  File "/usr/local/lib/python2.7/dist-packages/ansible/runner/__init__.py", line 789, in _executor_internal
    return self._executor_internal_inner(host, self.module_name, self.module_args, inject, port, complex_args=complex_args)
  File "/usr/local/lib/python2.7/dist-packages/ansible/runner/__init__.py", line 1004, in _executor_internal_inner
    module_args = template.template(self.basedir, module_args, inject, fail_on_undefined=self.error_on_undefined_vars)
  File "/usr/local/lib/python2.7/dist-packages/ansible/utils/template.py", line 124, in template
    varname = template_from_string(basedir, varname, templatevars, fail_on_undefined)
  File "/usr/local/lib/python2.7/dist-packages/ansible/utils/template.py", line 382, in template_from_string
    res = jinja2.utils.concat(rf)
  File "<template>", line 12, in root
  File "/usr/lib/python2.7/dist-packages/jinja2/filters.py", line 318, in do_join
    return text_type(d).join(imap(text_type, value))
  File "/usr/lib/python2.7/dist-packages/jinja2/filters.py", line 839, in do_map
    for item in seq:
  File "/usr/lib/python2.7/dist-packages/jinja2/filters.py", line 931, in _select_or_reject
    if modfunc(func(transfunc(item))):
  File "/usr/lib/python2.7/dist-packages/jinja2/filters.py", line 925, in <lambda>
    name, item, args, kwargs)
  File "/usr/lib/python2.7/dist-packages/jinja2/environment.py", line 438, in call_test
    raise TemplateRuntimeError('no test named %r' % name)
TemplateRuntimeError: no test named 'equalto'


FATAL: all hosts have already failed -- aborting
```

It's all because **jinja2** version installed on my host machine (only dev version of jinja provides **equalto** filter). It's necessary to point in documentation that cibox requires **jinja2 (2.8 dev)**.