### PR TITLE
Fix MySQL service after vagrant up

### DIFF
--- a/core/cibox-project-builder/files/drupal7/scripts/devops/reinstall/sql_workflow.yml
+++ b/core/cibox-project-builder/files/drupal7/scripts/devops/reinstall/sql_workflow.yml
@@ -4,6 +4,12 @@
 # - Importing to database
 # - Running registry rebuild (when modules have been moved to new directory)
 # - Running database updates
+- name: Start the MySQL service
+  service: 
+    name: mysql 
+    state: started
+    enabled: true
+    
 - name: Droping drupal database
   mysql_db: name={{ mysql_db }} state=absent login_user={{ mysql_user }} login_password={{ mysql_pass }} login_host={{ mysql_host }}
   when: pp_environment == "demo" or pp_environment == "default"

--- a/core/cibox-project-builder/files/drupal8/scripts/devops/reinstall/sql_workflow.yml
+++ b/core/cibox-project-builder/files/drupal8/scripts/devops/reinstall/sql_workflow.yml
@@ -4,6 +4,12 @@
 # - Importing to database
 # - Running registry rebuild (when modules have been moved to new directory)
 # - Running database updates
+- name: Start the MySQL service
+  service: 
+    name: mysql 
+    state: started
+    enabled: true
+    
 - name: Droping drupal database
   mysql_db: name={{ mysql_db }} state=absent login_user={{ mysql_user }} login_password={{ mysql_pass }}
   when: pp_environment == "demo" or pp_environment == "default"


### PR DESCRIPTION
Those changes fix local build when for some reason MySQL hasn't been started on boot.
Also it fix issue with PR builder, because by default in our image MySQL isn't started.
