### PR TITLE
Revert features while site reinstalling process for sql flow

### DIFF
--- a/core/cibox-project-builder/files/drupal7/scripts/devops/reinstall/sql_workflow.yml
+++ b/core/cibox-project-builder/files/drupal7/scripts/devops/reinstall/sql_workflow.yml
@@ -73,3 +73,6 @@
 - name: Updating database
   sudo: yes
   shell: "{{ php_env_vars }} drush -dvy updb -l {{ site_url }}"
+
+- name: Revert features
+  shell: "{{ php_env_vars }} drush -y fra"

--- a/core/cibox-project-builder/files/drupal7/scripts/devops/reinstall/sql_workflow.yml
+++ b/core/cibox-project-builder/files/drupal7/scripts/devops/reinstall/sql_workflow.yml
@@ -76,3 +76,4 @@
 
 - name: Revert features
   shell: "{{ php_env_vars }} drush -y fra"
+  when: sql_workflow_features_revert_all

--- a/core/cibox-project-builder/files/drupal7/scripts/devops/reinstall/vars/global_settings.yml
+++ b/core/cibox-project-builder/files/drupal7/scripts/devops/reinstall/vars/global_settings.yml
@@ -19,6 +19,7 @@ pp_environment: 'default'
 # This variable allows select type of installation. Can be overridden by CI server.
 # From installation profile = 'profile', from sql dump = 'sql'.
 workflow_type: 'profile'
+sql_workflow_features_revert_all: false
 is_windows: false
 ci_server_username: 'jenkins'
 # This variable allows make backup from CI environment before processing.

--- a/core/cibox-project-builder/files/drupal8/scripts/devops/reinstall/sql_workflow.yml
+++ b/core/cibox-project-builder/files/drupal8/scripts/devops/reinstall/sql_workflow.yml
@@ -67,3 +67,6 @@
 - name: Updating database
   sudo: yes
   shell: "{{ php_env_vars }} drush -dvy updb -l {{ site_url }}"
+
+- name: Revert features
+  shell: "{{ php_env_vars }} drush -y fra"

--- a/core/cibox-project-builder/files/drupal8/scripts/devops/reinstall/sql_workflow.yml
+++ b/core/cibox-project-builder/files/drupal8/scripts/devops/reinstall/sql_workflow.yml
@@ -70,3 +70,4 @@
 
 - name: Revert features
   shell: "{{ php_env_vars }} drush -y fra"
+  when: sql_workflow_features_revert_all

--- a/core/cibox-project-builder/files/drupal8/scripts/devops/reinstall/vars/global_settings.yml
+++ b/core/cibox-project-builder/files/drupal8/scripts/devops/reinstall/vars/global_settings.yml
@@ -19,6 +19,7 @@ pp_environment: 'default'
 # This variable allows select type of installation. Can be overridden by CI server.
 # From installation profile = 'profile', from sql dump = 'sql'.
 workflow_type: 'profile'
+sql_workflow_features_revert_all: false
 is_windows: false
 ci_server_username: 'jenkins'
 # This variable allows make backup from CI environment before processing.


### PR DESCRIPTION
We think it's a good idea to revert all features during reinstall process for sql flow. So instead of call something like this
```
function some_module_features_revert_module(array $features) {
  foreach ($features as $feature) {
    features_revert_module($feature);
  }
}
```
for updated features in each `hook_update_N` just do...nothing.

Suggested by @ban6ka