### PR TITLE
Fix wrong declaration of temp folder

### DIFF
--- a/core/cibox-project-builder/files/drupal8/scripts/devops/reinstall/vars/environments/default_env.yml
+++ b/core/cibox-project-builder/files/drupal8/scripts/devops/reinstall/vars/environments/default_env.yml
@@ -5,7 +5,7 @@ env:
     - { name: '$config_directories["staging"]', status: false, value: 'sites/default/config/staging' }
     - { name: '$settings["install_profile"]', status: true, value: "{{ installation_profile_name }}" }
     - { name: '$settings["file_public_path"]', status: true, value: 'sites/default/files' }
-    - { name: '$config["system.file"]["path.temporary"]', status: true, value: '/tmp' }
+    - { name: '$config["system.file"]["path"]["temporary"]', status: true, value: '/tmp' }
   modules:
     - { name: 'devel config_inspector config_devel', status: false }
   drush_commands:


### PR DESCRIPTION
Looks like declaration of temp folder is wrong based on https://docs.acquia.com/cloud/develop/files/broken
it should be `["system.file"]["path"]["temporary"]` instead of `["system.file"]["path.temporary"]`.

For testing purposes I've added this two lines in settings.php
`$config["system.file"]["path"]["temporary"] = "/tmp/thisislocal";`
`$config["system.file"]["path.temporary"] = "/tmp"`

Drush config get with special option that shows overrides (https://www.drupal.org/docs/8/api/configuration-api/configuration-override-system) returned both values as **two different config values**.

> vagrant@precise64:/vagrant/docroot$ drush cget system.file --include-overridden
allow_insecure_uploads: false
default_scheme: public
path:
  **temporary: /tmp/thisislocal**
temporary_maximum_age: 21600
_core:
  default_config_hash: t48gCU9DzYfjb3bAOIqHLzhL0ChBlXh6_5B5Pyo9t8g
**path.temporary: /tmp**
