### PR TITLE
Forward port 443 from host to guest.

### DIFF
--- a/core/cibox-project-builder/files/vagrant/box/provisioning/config.yaml
+++ b/core/cibox-project-builder/files/vagrant/box/provisioning/config.yaml
@@ -11,6 +11,9 @@ vagrantfile-local:
                 CocLsFE7aIwE:
                     host: '8083'
                     guest: '3306'
+                CocLsFE7aIwF:
+                    host: '443'
+                    guest: '443'
         provider:
             virtualbox:
                 box: 'u14.04php5.6.box'


### PR DESCRIPTION
After configuring SSL on local cibox site kept showing connection not allowed. After adding
`config.vm.network "forwarded_port", guest: 443, host: 443`
to `Vagrantfile` and reloading the machine it started to work. 

To fix the problem forward rule needs to be added during provisioning. This patch solves this problem.

Please review.