### PR TITLE
Updated shell scripts based on recommendations from shellcheck linter

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -5,11 +5,11 @@
 export PYTHONUNBUFFERED=1
 
 # Get server IP from config.yml
-IP=`cat config.yml | grep -E '^server_ip:\s.*$' | cut -d" " -f2`
+IP=$(grep -E '^server_ip:\s.*$' config.yml | cut -d" " -f2)
 
 if [ -z "${IP}" ]; then
     echo "Please specify IP address in config.yml"
     exit
 fi
 
-ansible-playbook -vvvv -i $IP, services/jenkinsbox.yml --extra-vars "@config.yml"
+ansible-playbook -vvvv -i "${IP}", services/jenkinsbox.yml --extra-vars "@config.yml"

--- a/requirements.sh
+++ b/requirements.sh
@@ -4,7 +4,7 @@
 help="Visit http://docs.cibox.tools/en/latest/Requirements for more information."
 ansible=$(which ansible)
 
-if [ -z ${ansible} ]; then
+if [ -z "${ansible}" ]; then
   echo "Ansible not installed. Further interaction is not possible. ${help}"
   exit 1
 fi
@@ -17,7 +17,7 @@ ansible_version_required="1.9.4"
 # Use the second column from first row.
 ansible_version_current=$(${ansible} --version | head -1 | awk '{print $2}')
 
-if ! echo ${ansible_version_current} | grep ${ansible_version_required} >/dev/null; then
+if ! echo "${ansible_version_current}" | grep ${ansible_version_required} >/dev/null; then
   echo "You have installed Ansible ${ansible_version_current}, but CIBox requires ${ansible_version_required}. ${help}"
   exit 2
 fi


### PR DESCRIPTION
I have run the shell scripts through [shellcheck](https://github.com/koalaman/shellcheck), a bash linter. The following errors have come up and have been corrected in this commit:

![screenshot_20170402_231053](https://cloud.githubusercontent.com/assets/4750917/24591500/867bc664-17fa-11e7-9176-fb14098736da.png)

In summary the errors found where:

- [SC2006](https://github.com/koalaman/shellcheck/wiki/SC2006) - Legacy use of backquotes
- [SC2002](https://github.com/koalaman/shellcheck/wiki/SC2002) - Useless cat
- [SC2086](https://github.com/koalaman/shellcheck/wiki/SC2086) - Use double quotes to prevent globbing and word splitting.