### PR TITLE
Remove URL to the outdated git repository

### DIFF
--- a/core/cibox-project-builder/files/drupal7/scripts/sniffers.yml
+++ b/core/cibox-project-builder/files/drupal7/scripts/sniffers.yml
@@ -34,13 +34,11 @@
       - { package: 'squizlabs/php_codesniffer', version: '=2.*' }
 
     git_repos:
-      - { branch: 'master', repo: 'http://git.drupal.org/sandbox/coltrane/1921926.git', name: 'DrupalSecure' } # git clone --branch master http://git.drupal.org/sandbox/coltrane/1921926.git DrupalSecure
       - { branch: 'master', repo: 'https://github.com/podarok/phpcs-security-audit.git', name: 'Security' } #git clone --branch master https://github.com/podarok/phpcs-security-audit.git Security
       - { branch: 'master', repo: 'https://github.com/podarok/Symfony2-coding-standard.git', name: 'Symfony2' }
 
     phpcs_standards:
       - { path: 'vendor/drupal/coder/coder_sniffer/Drupal', name: 'Drupal' } #/root/.composer/vendor/drupal/coder/coder_sniffer/Drupal Drupal
-      - { path: 'vendor/podarok/DrupalSecure/DrupalSecure', name: 'DrupalSecure' } #/root/.composer/vendor/podarok/DrupalSecure DrupalSecure
       - { path: 'vendor/podarok/Security/Security', name: 'Security' } #/root/.composer/vendor/podarok/Security Security
 
     npm_packages:

--- a/core/cibox-project-builder/files/drupal8/scripts/sniffers.yml
+++ b/core/cibox-project-builder/files/drupal8/scripts/sniffers.yml
@@ -31,13 +31,11 @@
       - squizlabs/php_codesniffer=2.9.x-dev
       - drupal/coder:dev-8.x-2.x
     git_repos:
-      - { branch: 'master', repo: 'http://git.drupal.org/sandbox/coltrane/1921926.git', name: 'DrupalSecure' } # git clone --branch master http://git.drupal.org/sandbox/coltrane/1921926.git DrupalSecure
       - { branch: 'master', repo: 'https://github.com/podarok/phpcs-security-audit.git', name: 'Security' } #git clone --branch master https://github.com/podarok/phpcs-security-audit.git Security
       - { branch: 'master', repo: 'https://github.com/podarok/Symfony2-coding-standard.git', name: 'Symfony2' }
 
     phpcs_standards:
       - { path: 'vendor/drupal/coder/coder_sniffer/Drupal', name: 'Drupal' } #/root/.composer/vendor/drupal/coder/coder_sniffer/Drupal Drupal
-      - { path: 'vendor/podarok/DrupalSecure/DrupalSecure', name: 'DrupalSecure' } #/root/.composer/vendor/podarok/DrupalSecure DrupalSecure
       - { path: 'vendor/podarok/Security/Security', name: 'Security' } #/root/.composer/vendor/podarok/Security Security
 
     npm_packages:

--- a/core/cibox-sniffers/defaults/main.yml
+++ b/core/cibox-sniffers/defaults/main.yml
@@ -7,7 +7,6 @@ composer_global_require:
   - { package: 'squizlabs/php_codesniffer', version: '=2.*' }
 
 git_repos:
-  - { branch: 'master', repo: 'http://git.drupal.org/sandbox/coltrane/1921926.git', name: 'DrupalSecure' } # git clone --branch master http://git.drupal.org/sandbox/coltrane/1921926.git DrupalSecure
   - { branch: 'master', repo: 'https://github.com/podarok/Symfony2-coding-standard.git', name: 'Symfony2' }
 
 phpcs_standards:


### PR DESCRIPTION
Steps for review:
- [ ] Review code changes
- [ ] Verify you do not see next errors when running sniffers 
```
08:35:42 TASK: [Install php codesniffer standards] ************************************* 
08:35:42 failed: [localhost] => (item={'path': 'vendor/drupal/coder/coder_sniffer/Drupal', 'name': 'Drupal'}) => {"failed": true, "item": {"name": "Drupal", "path": "vendor/drupal/coder/coder_sniffer/Drupal"}, "path": "/usr/share/composer/vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/Drupal", "state": "absent"}
08:35:42 msg: Error while linking: [Errno 2] No such file or directory
08:35:42 failed: [localhost] => (item={'path': 'vendor/podarok/Security/Security', 'name': 'Security'}) => {"failed": true, "item": {"name": "Security", "path": "vendor/podarok/Security/Security"}, "path": "/usr/share/composer/vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/Security", "state": "absent"}
08:35:42 msg: Error while linking: [Errno 2] No such file or directory
08:35:42 
08:35:42 FATAL: all hosts have already failed -- aborting
``