### PR TITLE
#563: Fixed drupal_release for MacOS and Ubuntu

### DIFF
--- a/core/cibox-project-builder/tasks/drupal.yml
+++ b/core/cibox-project-builder/tasks/drupal.yml
@@ -17,8 +17,11 @@
     force: yes
 
 - name: Extract current release
-  shell: "grep -oP '(?<=version>)[^<]+' /tmp/drupal_update.xml | head -2 | tail -1"
+  shell: 'grep -E -m 1 -o "<version>[0-9]{1,4}.[0-9]{1,4}.[0-9]{1,4}</version>" /tmp/drupal_update.xml | head -1 | tail -1 | sed -e "s,.*<version>\([^<]*\)</version>.*,\1,g"'
   register: drupal_release
+
+- debug:
+    msg: "Drupal version - {{ drupal_release.stdout }}"
 
 - name: Download Drupal to temporary directory
   get_url:


### PR DESCRIPTION
Related to #563.

Perl regexp is not supported in MacOS by default. We have to change it to default regexp.

Tested on MacOS.
![screen shot 2017-08-01 at 3 22 52 pm](https://user-images.githubusercontent.com/1316234/28825131-ae8661a0-76cd-11e7-8842-43e0b66d1bed.png)

Tested on Ubuntu.
![screen shot 2017-08-01 at 3 23 00 pm](https://user-images.githubusercontent.com/1316234/28825125-a60db668-76cd-11e7-8b22-0f5c1ae1f341.png)
