### PR TITLE
Allow to commit vendors

### DIFF
--- a/core/cibox-project-builder/tasks/drupal.yml
+++ b/core/cibox-project-builder/tasks/drupal.yml
@@ -98,6 +98,12 @@
     dest: '{{ repo_subfolder }}/{{ drupal_subfolder }}/.htaccess'
     line: '# Restrict access to YAML files.\n<Files ~ "\.yml$">\n  Order Allow,Deny\n  Deny from All\n</Files>'
 
+- name: Allow to commit vendor's folder
+  lineinfile:
+    dest: '{{ repo_subfolder }}/{{ drupal_subfolder }}/.gitignore'
+    regexp: '^vendor'
+    line: '# vendor'
+
 - name: Create Behat folder
   file:
     path: '{{ repo_subfolder }}/tests/behat'


### PR DESCRIPTION
Whenever we start Drupal 8 project, 1st thing that we see - error because vendor folder hasn't bee commited.