### PR TITLE
Remove behat tests from PR builder

### DIFF
--- a/core/cibox-jenkins/templates/jobs/pr_builder.xml.j2
+++ b/core/cibox-jenkins/templates/jobs/pr_builder.xml.j2
@@ -292,54 +292,6 @@
                 </org.jenkinsci.plugins.ansible.ExtraVar>
             </extraVars>
         </org.jenkinsci.plugins.ansible.AnsiblePlaybookBuilder>
-        <org.jenkinsci.plugins.ansible.AnsiblePlaybookBuilder plugin="ansible@0.5">
-            <playbook>/var/www/build${BUILD_NUMBER}/tests.yml</playbook>
-            <limit></limit>
-            <tags></tags>
-            <skippedTags></skippedTags>
-            <startAtTask></startAtTask>
-            <credentialsId></credentialsId>
-            <sudo>false</sudo>
-            <sudoUser></sudoUser>
-            <forks>5</forks>
-            <unbufferedOutput>true</unbufferedOutput>
-            <colorizedOutput>true</colorizedOutput>
-            <hostKeyChecking>false</hostKeyChecking>
-            <additionalParameters> -i 'localhost,' --connection=local</additionalParameters>
-            <copyCredentialsInWorkspace>false</copyCredentialsInWorkspace>
-            <extraVars>
-                <org.jenkinsci.plugins.ansible.ExtraVar>
-                    <key>workspace_root</key>
-                    <value>${WORKSPACE}</value>
-                    <hidden>false</hidden>
-                </org.jenkinsci.plugins.ansible.ExtraVar>
-                <org.jenkinsci.plugins.ansible.ExtraVar>
-                    <key>behat_base_url</key>
-                    <value>http://{{ jenkins_server_ip }}/build${BUILD_NUMBER}</value>
-                    <hidden>false</hidden>
-                </org.jenkinsci.plugins.ansible.ExtraVar>
-                <org.jenkinsci.plugins.ansible.ExtraVar>
-                    <key>update_dependencies</key>
-                    <value>yes</value>
-                    <hidden>false</hidden>
-                </org.jenkinsci.plugins.ansible.ExtraVar>
-                <org.jenkinsci.plugins.ansible.ExtraVar>
-                    <key>resources_path</key>
-                    <value>${WORKSPACE}/{{ jenkins_sourcode_folder }}/tests/behat/resources</value>
-                    <hidden>false</hidden>
-                </org.jenkinsci.plugins.ansible.ExtraVar>
-                <org.jenkinsci.plugins.ansible.ExtraVar>
-                    <key>behat_drupal_root</key>
-                    <value>/var/www/build${BUILD_NUMBER}</value>
-                    <hidden>false</hidden>
-                </org.jenkinsci.plugins.ansible.ExtraVar>
-                <org.jenkinsci.plugins.ansible.ExtraVar>
-                    <key>behat_root</key>
-                    <value>${WORKSPACE}/{{ jenkins_sourcode_folder }}/tests/behat</value>
-                    <hidden>false</hidden>
-                </org.jenkinsci.plugins.ansible.ExtraVar>
-            </extraVars>
-        </org.jenkinsci.plugins.ansible.AnsiblePlaybookBuilder>
     </builders>
     <publishers />
     <buildWrappers>


### PR DESCRIPTION
Whenever we create new project, behat tests are failed, so we end up going to Jenkins UI and removing them from PR_BUILDER.



There are a lot of reasons to remove them for now:
- There are only a few project that are using behat tests with a lot of customization
- Behat tests should use Docker
- New implementation should be backported from projects
- Noone is maintaining them
- ...

This is kinda hotfix and at some point new implmentation should be added as lazy builder.

![image](https://user-images.githubusercontent.com/1316234/29026483-a40f7b1a-7b84-11e7-97ad-d2188ff5d9a6.png)
