### PR TITLE
Drupal 8 Reinstall scripts update: add missing `login_host` to all mysql actions

### DIFF
--- a/core/cibox-project-builder/files/drupal8/scripts/devops/reinstall/database_backup.yml
+++ b/core/cibox-project-builder/files/drupal8/scripts/devops/reinstall/database_backup.yml
@@ -13,7 +13,7 @@
 
 - name: Making regular backup from {{ local_backup_environment }} environment
   sudo: yes
-  mysql_db: name={{ local_backup_environment }} state=dump target={{ backup_folder }}/{{ local_backup_environment }}_local/{{ backup_name }}.sql.gz login_user={{ mysql_user }} login_password={{ mysql_pass }}
+  mysql_db: name={{ local_backup_environment }} state=dump target={{ backup_folder }}/{{ local_backup_environment }}_local/{{ backup_name }}.sql.gz login_user={{ mysql_user }} login_password={{ mysql_pass }} login_host={{ mysql_host }}
 
 - name: Make new backup as latest
   sudo: yes

--- a/core/cibox-project-builder/files/drupal8/scripts/devops/reinstall/sql_workflow.yml
+++ b/core/cibox-project-builder/files/drupal8/scripts/devops/reinstall/sql_workflow.yml
@@ -11,11 +11,11 @@
     enabled: true
     
 - name: Droping drupal database
-  mysql_db: name={{ mysql_db }} state=absent login_user={{ mysql_user }} login_password={{ mysql_pass }}
+  mysql_db: name={{ mysql_db }} state=absent login_user={{ mysql_user }} login_password={{ mysql_pass }} login_host={{ mysql_host }}
   when: pp_environment == "demo" or pp_environment == "default"
 
 - name: Creating drupal database
-  mysql_db: name={{ mysql_db }} state=present login_user={{ mysql_user }} login_password={{ mysql_pass }}
+  mysql_db: name={{ mysql_db }} state=present login_user={{ mysql_user }} login_password={{ mysql_pass }} login_host={{ mysql_host }}
 
 # Vagrant build.
 - name: Downloading latest backup to local environment
@@ -28,7 +28,7 @@
   when: pp_environment == "default" and ((ansible_env.USER is not defined or ansible_env.USER != "{{ ci_server_username }}") and (ansible_env.SUDO_USER is not defined or ansible_env.SUDO_USER != "{{ ci_server_username }}"))
 
 - name: Importing from remote backup
-  mysql_db: name={{ mysql_db }} state=import target={{ backup_folder }}/latest_remote.sql.gz login_user={{ mysql_user }} login_password={{ mysql_pass }}
+  mysql_db: name={{ mysql_db }} state=import target={{ backup_folder }}/latest_remote.sql.gz login_user={{ mysql_user }} login_password={{ mysql_pass }} login_host={{ mysql_host }}
   sudo: yes
   when: pp_environment == "default" and ((ansible_env.USER is not defined or ansible_env.USER != "{{ ci_server_username }}") and (ansible_env.SUDO_USER is not defined or ansible_env.SUDO_USER != "{{ ci_server_username }}"))
 
@@ -39,7 +39,7 @@
   when: (pp_environment == "default" or pp_environment == "demo") and ((ansible_env.USER is defined and ansible_env.USER == "{{ ci_server_username }}") or (ansible_env.SUDO_USER is defined and ansible_env.SUDO_USER == "{{ ci_server_username }}"))
 
 - name: Importing from local backup
-  mysql_db: name={{ mysql_db }} state=import target=./latest.sql.gz login_user={{ mysql_user }} login_password={{ mysql_pass }}
+  mysql_db: name={{ mysql_db }} state=import target=./latest.sql.gz login_user={{ mysql_user }} login_password={{ mysql_pass }} login_host={{ mysql_host }}
   sudo: yes
   when: (pp_environment == "default" or pp_environment == "demo") and ((ansible_env.USER is defined and ansible_env.USER == "{{ ci_server_username }}") or (ansible_env.SUDO_USER is defined and ansible_env.SUDO_USER == "{{ ci_server_username }}"))
 


### PR DESCRIPTION
## Problem

I found that following ansible script templates for D8 Reinstall do not contain `login_host={{ mysql_host }}`:
- [database_backup.yml](https://github.com/cibox/cibox/blob/master/core/cibox-project-builder/files/drupal8/scripts/devops/reinstall/database_backup.yml)
- [sql_workflow.yml](https://github.com/cibox/cibox/blob/master/core/cibox-project-builder/files/drupal8/scripts/devops/reinstall/sql_workflow.yml)

But D7 scripts have this parameter:
- [database_backup.yml](https://github.com/cibox/cibox/blob/master/core/cibox-project-builder/files/drupal7/scripts/devops/reinstall/database_backup.yml)
- [sql_workflow.yml](https://github.com/cibox/cibox/blob/master/core/cibox-project-builder/files/drupal7/scripts/devops/reinstall/sql_workflow.yml)

## Reason why to fix
Its handy to use external databases for cibox integrated projects. For example I have MySQL server on my host machine that shows damn much better performance than MySQL server in VirtualBox and project works much faster using it instead of MySQL inside virtual machine.

## Solution
- There is [`mysql_host`](https://github.com/cibox/cibox/blob/master/core/cibox-project-builder/files/drupal8/scripts/devops/reinstall/vars/global_settings.yml#L8) variable in D8's `global_settings.yml`  
- Just add  `login_host={{ mysql_host }}` to all places in reinstall scripts where its required.

## Potential problems after fix
- Not found

Thank you! 